### PR TITLE
Remove magic number using http status code

### DIFF
--- a/clients/baseClient.go
+++ b/clients/baseClient.go
@@ -80,7 +80,7 @@ func CreateClient(service string, config *Config, workspaceBound bool) *gentlema
 
 func responseErrors() plugin.Plugin {
 	return plugin.NewResponsePlugin(func(c *context.Context, h context.Handler) {
-		if 200 <= c.Response.StatusCode && c.Response.StatusCode < 400 {
+		if http.StatusOK <= c.Response.StatusCode && c.Response.StatusCode < http.StatusNotFound {
 			h.Next(c)
 			return
 		}


### PR DESCRIPTION
This PR removes magic numbers used in BaseClient file that check the status code of a response.