### PR TITLE
Fix case-insensitive import collision

### DIFF
--- a/clients/ioHeadersRecorder.go
+++ b/clients/ioHeadersRecorder.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	uuid "github.com/satori/go.uuid"
 )
 


### PR DESCRIPTION
We are using an old version of `Sirupsen`. The recommendation is always use it like `sirupsen` and avoid import collisions with others libs which are using this one.