### PR TITLE
Fix: logrus new import path (https://github.com/sirupsen/logrus/issue…

### DIFF
--- a/clients/ioHeadersRecorder.go
+++ b/clients/ioHeadersRecorder.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 )
 
 var (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix logrus import problems:
```
    github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.4.2: parsing go.mod:
    module declares its path as: github.com/sirupsen/logrus
            but was required as: github.com/Sirupsen/logrus
```

#### What problem is this solving?
When using this repository with new logrus versions, I got `module declares` error.
More details here: https://github.com/sirupsen/logrus/issues/1041


#### How should this be manually tested?
Just try to build some golang project using this repo as dependency.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
